### PR TITLE
support for voiding labels/postage

### DIFF
--- a/test/test_endicia.rb
+++ b/test/test_endicia.rb
@@ -586,7 +586,7 @@ class TestEndicia < Test::Unit::TestCase
     should "include response body in return hash" do
       response = stub_everything("response", :body => "the response body")
       Endicia.stubs(:get).returns(response)
-      result = Endicia.status_request("the tracking number")
+      result = Endicia.refund_request("the tracking number")
       assert_equal "the response body", result[:response_body]
     end
     


### PR DESCRIPTION
added rudimentary support (and tests!) for Endicia's RefundRequest method
code was heavily based on your implementation of status_request

some limitations:
- requires that you know the label's tracking number
- supports only one void per call
- doesn't allow you to specify a value for the CustomsID field (which prevents support for voiding PriorityMailInternational and ExpressMailInternational labels) probably wouldn't be too difficult to add... we just didn't need it right now.
